### PR TITLE
Use abstracts instead of an interface

### DIFF
--- a/common/common.routes.config.ts
+++ b/common/common.routes.config.ts
@@ -1,13 +1,15 @@
 import express from 'express';
-export class CommonRoutesConfig {
+export abstract class CommonRoutesConfig {
     app: express.Application;
     name: string;
 
     constructor(app: express.Application, name: string) {
         this.app = app;
         this.name = name;
+        this.configureRoutes();
     }
     getName() {
         return this.name;
     }
+    abstract configureRoutes(): express.Application;
 }

--- a/common/common.routes.interface.ts
+++ b/common/common.routes.interface.ts
@@ -1,5 +1,0 @@
-import express from "express";
-
-export interface CommonRoutesInterface {
-    configureRoutes(): express.Application;
-}

--- a/users/users.routes.config.ts
+++ b/users/users.routes.config.ts
@@ -1,11 +1,9 @@
 import {CommonRoutesConfig} from '../common/common.routes.config';
-import {CommonRoutesInterface} from '../common/common.routes.interface'
 import express from 'express';
 
-export class UsersRoutes extends CommonRoutesConfig implements CommonRoutesInterface {
+export class UsersRoutes extends CommonRoutesConfig {
     constructor(app: express.Application) {
-        super(app, 'UsersRoute');
-        this.configureRoutes();
+        super(app, 'UsersRoutes');
     }
 
     configureRoutes() {


### PR DESCRIPTION
- Forces implementation without having to remember the implements keyword
- Reduces boilerplate call to configureRoutes() by moving it to the base constructor
- Fixes a Route→Routes typo along the way