### PR TITLE
Reuse middleware logic

### DIFF
--- a/users/middleware/users.middleware.ts
+++ b/users/middleware/users.middleware.ts
@@ -39,16 +39,10 @@ class UsersMiddleware {
 
     async validatePatchEmail(req: express.Request, res: express.Response, next: express.NextFunction) {
         if (req.body.email) {
-            const user = await userService.getUserByEmail(req.body.email);
-            if (user && user.id === req.params.userId) {
-                next();
-            } else {
-                res.status(400).send({error: `Invalid email`});
-            }
+            UsersMiddleware.getInstance().validateSameEmailBelongToSameUser(req, res, next);
         } else {
             next();
         }
-
     }
 
     async validateUserExists(req: express.Request, res: express.Response, next: express.NextFunction) {


### PR DESCRIPTION
(Using `this.` instead of `UsersMiddleware.getInstance().` unfortunately doesn't work because `this` is undefined in context, but I think it's still nice to follow DRY principles here.)