### PR TITLE
Close and disconnect instead of using `--exit` workaround

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -45,11 +45,9 @@ app.use(expressWinston.errorLogger({
 app.get('/', (req: express.Request, res: express.Response) => {
     res.status(200).send(`Server running at http://localhost:${port}`)
 });
-server.listen(port, () => {
+export default server.listen(port, () => {
     debugLog(`Server running at http://localhost:${port}`);
     routes.forEach((route: CommonRoutesConfig) => {
         debugLog(`Routes configured for ${route.getName()}`);
     });
 });
-
-export default app;

--- a/package-lock.json
+++ b/package-lock.json
@@ -449,6 +449,11 @@
       "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.5.tgz",
       "integrity": "sha512-kDuEzldR21lHciPQAIulLs1LZlCXdLziXI6Mb/TDkwXhb//UORJNPXgcRs2CuO4H0DcMkpfT3/ySsP3unoZjBg=="
     },
+    "buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
+    },
     "buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
@@ -767,6 +772,14 @@
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
       "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
       "dev": true
+    },
+    "ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
     },
     "ee-first": {
       "version": "1.1.1",
@@ -1191,6 +1204,42 @@
         "esprima": "^4.0.0"
       }
     },
+    "jsonwebtoken": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
+      "integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
+      "requires": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^5.6.0"
+      }
+    },
+    "jwa": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+      "requires": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "requires": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "kareem": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.3.2.tgz",
@@ -1214,6 +1263,41 @@
       "version": "4.17.20",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
       "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+    },
+    "lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
+    },
+    "lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
+    },
+    "lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M="
+    },
+    "lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w="
+    },
+    "lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+    },
+    "lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
+    },
+    "lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
     },
     "log-symbols": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "tsc && node ./dist/app.js",
     "debug": "export DEBUG=* && npm start",
-    "test": "mocha -r ts-node/register test/**/*.test.ts --exit"
+    "test": "mocha -r ts-node/register test/**/*.test.ts"
   },
   "repository": {
     "type": "git",
@@ -32,6 +32,7 @@
     "debug": "^4.2.0",
     "express": "^4.17.1",
     "express-winston": "^4.0.5",
+    "jsonwebtoken": "^8.5.1",
     "mongoose": "~5.x.xx",
     "shortid": "^2.2.16",
     "winston": "^3.3.3"

--- a/test/users/users.test.ts
+++ b/test/users/users.test.ts
@@ -1,7 +1,8 @@
 import app from '../../app';
-import {agent as request} from 'supertest';
+import supertest from 'supertest';
 import {expect} from 'chai';
 import shortid from "shortid";
+import mongoose from 'mongoose';
 
 let firstUserIdTest = '';
 let firstUserBody = {
@@ -14,9 +15,14 @@ let refreshToken = '';
 const name = 'Jose';
 
 describe('Should test basic users endpoints', () => {
+    const request = supertest.agent(app);
+    after(done => {
+        // shut down the Express.js server, close our MongoDB connection, then tell Mocha we're done:
+        app.close(() => { mongoose.connection.close(done); });
+    });
 
     it('should POST /users', async function () {
-        const res = await request(app)
+        const res = await request
             .post('/users')
             .send(firstUserBody);
 
@@ -28,7 +34,7 @@ describe('Should test basic users endpoints', () => {
     });
 
     it('should post /auth', async function () {
-        const res = await request(app)
+        const res = await request
             .post('/auth')
             .send(firstUserBody);
         expect(res.status).to.equal(201);
@@ -40,7 +46,7 @@ describe('Should test basic users endpoints', () => {
     });
 
     it(`should GET /users/:userId`, async function () {
-        const res = await request(app)
+        const res = await request
             .get(`/users/${firstUserIdTest}`)
             .set({'Authorization': `Bearer ${accessToken}`})
             .send();
@@ -54,7 +60,7 @@ describe('Should test basic users endpoints', () => {
 
 
     it(`should GET /users`, async function () {
-        const res = await request(app)
+        const res = await request
             .get(`/users`)
             .set({'Authorization': `Bearer ${accessToken}`})
             .send();
@@ -63,7 +69,7 @@ describe('Should test basic users endpoints', () => {
 
     it.skip('should Patch /users/:userId', async function () {
 
-        const res = await request(app)
+        const res = await request
             .patch(`/users/${firstUserIdTest}`)
             .set({'Authorization': `Bearer ${accessToken}`})
             .send({
@@ -73,7 +79,7 @@ describe('Should test basic users endpoints', () => {
     });
 
     it.skip(`should GET /users/:userId to have a new name`, async function () {
-        const res = await request(app)
+        const res = await request
             .get(`/users/${firstUserIdTest}`)
             .set({'Authorization': `Bearer ${accessToken}`})
             .send();
@@ -87,7 +93,7 @@ describe('Should test basic users endpoints', () => {
     });
 
     it('should DELETE /users/:userId', async function () {
-        const res = await request(app)
+        const res = await request
             .delete(`/users/${firstUserIdTest}`)
             .set({'Authorization': `Bearer ${accessToken}`})
             .send();

--- a/users/services/users.service.ts
+++ b/users/services/users.service.ts
@@ -14,7 +14,7 @@ class UsersService implements CRUD {
 
     async create(resource: UserDto) {
         resource.permissionLevel = 1;
-        return await UsersDao.addUser(resource);
+        return UsersDao.addUser(resource);
     }
 
     async deleteById(resourceId: string) {
@@ -22,7 +22,7 @@ class UsersService implements CRUD {
     };
 
     async list(limit: number, page: number) {
-        return await UsersDao.getUsers(limit, page);
+        return UsersDao.getUsers(limit, page);
     };
 
     async patchById(userId: string, resource: UserDto): Promise<any> {
@@ -30,7 +30,7 @@ class UsersService implements CRUD {
     };
 
     async readById(resourceId: string) {
-        return await UsersDao.getUserById(resourceId);
+        return UsersDao.getUserById(resourceId);
     };
 
     async updateById(userId: string, resource: UserDto): Promise<any> {


### PR DESCRIPTION
Per the breaking change in Mocha 3→4, `--exit` can stop Mocha 4 from hanging, but hanging can indicate problems with test setup.  By closing the app and MongoDB connection to solve it instead, this means hanging can still properly indicate problems if they arise.  (In other words, preemptively using `--exit` might cover up a legitimate problem down the road.)