### PR TITLE
Fix Mongoose startup when Mongo isn't running

### DIFF
--- a/common/services/mongoose.service.ts
+++ b/common/services/mongoose.service.ts
@@ -6,7 +6,7 @@ const log: debug.IDebugger = debug('app:mongoose-service');
 class MongooseService {
     private static instance: MongooseService;
     private count = 0;
-    private mongooseOptions = { useNewUrlParser: true,  useUnifiedTopology: true  };
+    private mongooseOptions = { useNewUrlParser: true,  useUnifiedTopology: true, serverSelectionTimeoutMS: 5000 };
 
     constructor() {
         this.connectWithRetry();
@@ -23,7 +23,7 @@ class MongooseService {
         return mongoose;
     }
 
-    connectWithRetry() {
+    connectWithRetry = () => {
         log('MongoDB connection with retry');
         mongoose.connect("mongodb://localhost:27017/api-db",  this.mongooseOptions).then(() => {
             log('MongoDB is connected')


### PR DESCRIPTION
- Initial connect timeout defaults to 30s on Mongoose's end; 5s is more user-friendly here
- connectWithRetry needs the right `this` for setTimeout() to work; without this, you get the following output on startup in the absence of a MongoDB service:

```
  app:mongoose-service MongoDB connection unsuccessful, retry after 5 seconds. 1 +30s
  app:mongoose-service MongoDB connection with retry +5s
(node:8336) DeprecationWarning: current URL string parser is deprecated, and will be removed in a future version. To use the new parser, pass option { useNewUrlParser: true } to MongoClient.connect.
(node:8336) DeprecationWarning: current Server Discovery and Monitoring engine is deprecated, and will be removed in a future version. To use the new Server Discover and Monitoring engine, pass option { useUnifiedTopology: true } to the MongoClient constructor.
  app:mongoose-service MongoDB connection unsuccessful, retry after 5 seconds. NaN +16ms
(node:8336) UnhandledPromiseRejectionWarning: TypeError [ERR_INVALID_CALLBACK]: Callback must be a function. Received undefined
    at setTimeout (timers.js:122:11)
    at /path/to/toptal-rest-series/dist/common/services/mongoose.service.js:30:13
    at processTicksAndRejections (internal/process/task_queues.js:97:5)
(node:8336) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 1)
(node:8336) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```