### PR TITLE
Standardize "id" for user CRUD

### DIFF
--- a/common/interfaces/crud.interface.ts
+++ b/common/interfaces/crud.interface.ts
@@ -2,7 +2,7 @@ export interface CRUD {
     list: (limit: number, page: number) => Promise<any>,
     create: (resource: any) => Promise<any>,
     updateById: (id: string, resource: any) => Promise<string>,
-    readById: (resourceId: any) => Promise<any>,
-    deleteById: (resourceId: any) => Promise<string>,
+    readById: (id: string) => Promise<any>,
+    deleteById: (id: string) => Promise<string>,
     patchById: (id: string, resource: any) => Promise<string>,
 }

--- a/users/services/users.service.ts
+++ b/users/services/users.service.ts
@@ -17,24 +17,24 @@ class UsersService implements CRUD {
         return UsersDao.addUser(resource);
     }
 
-    async deleteById(resourceId: string) {
-        return UsersDao.removeUserById(resourceId);
+    async deleteById(id: string) {
+        return UsersDao.removeUserById(id);
     };
 
     async list(limit: number, page: number) {
         return UsersDao.getUsers(limit, page);
     };
 
-    async patchById(userId: string, resource: UserDto): Promise<any> {
-        return UsersDao.patchUserById(userId, resource)
+    async patchById(id: string, resource: UserDto): Promise<any> {
+        return UsersDao.patchUserById(id, resource)
     };
 
-    async readById(resourceId: string) {
-        return UsersDao.getUserById(resourceId);
+    async readById(id: string) {
+        return UsersDao.getUserById(id);
     };
 
-    async updateById(userId: string, resource: UserDto): Promise<any> {
-        return UsersDao.patchUserById(userId, resource);
+    async updateById(id: string, resource: UserDto): Promise<any> {
+        return UsersDao.patchUserById(id, resource);
     };
 
     async getUserByEmail(email: string) {


### PR DESCRIPTION
Separate from the _id vs id question.  I thought `string` would be better than `any` here, and I couldn't see the reason behind `resourceId` vs `userId` vs simply `id` (but in case there is one, this is a separate PR.)