### PR TITLE
Replace function with factory call and finish level→flags rename

### DIFF
--- a/common/middleware/common.permission.middleware.ts
+++ b/common/middleware/common.permission.middleware.ts
@@ -46,19 +46,6 @@ class CommonPermissionMiddleware {
             }
         }
     }
-
-    async onlyAdminCanDoThisAction(
-        req: express.Request,
-        res: express.Response,
-        next: express.NextFunction
-    ) {
-        const userPermissionFlags = parseInt(res.locals.jwt.permissionFlags);
-        if (userPermissionFlags & PermissionFlag.ADMIN_PERMISSION) {
-            return next();
-        } else {
-            return res.status(403).send();
-        }
-    }
 }
 
 export default new CommonPermissionMiddleware();

--- a/test/users/users.test.ts
+++ b/test/users/users.test.ts
@@ -94,7 +94,7 @@ describe('users and auth endpoints', function () {
             expect(res.status).to.equal(404);
         });
 
-        it('should disallow a PUT to /users/:userId trying to change the permission level', async function () {
+        it('should disallow a PUT to /users/:userId trying to change the permission flags', async function () {
             const res = await request
                 .put(`/users/${firstUserIdTest}`)
                 .set({ Authorization: `Bearer ${accessToken}` })
@@ -109,7 +109,7 @@ describe('users and auth endpoints', function () {
             expect(res.body.errors).to.be.an('array');
             expect(res.body.errors).to.have.length(1);
             expect(res.body.errors[0]).to.equal(
-                'User cannot change permission level'
+                'User cannot change permission flags'
             );
         });
 
@@ -121,7 +121,7 @@ describe('users and auth endpoints', function () {
             expect(res.status).to.equal(204);
         });
 
-        describe('with a new permission level', async function () {
+        describe('with a new set of permission flags', async function () {
             it('should allow a POST to /auth/refresh-token', async function () {
                 const res = await request
                     .post('/auth/refresh-token')

--- a/users/middleware/users.middleware.ts
+++ b/users/middleware/users.middleware.ts
@@ -36,7 +36,7 @@ class UsersMiddleware {
     ) {
         if (res.locals.user.permissionFlags !== req.body.permissionFlags) {
             res.status(400).send({
-                errors: ['User cannot change permission level'],
+                errors: ['User cannot change permission flags'],
             });
         } else {
             next();

--- a/users/users.routes.config.ts
+++ b/users/users.routes.config.ts
@@ -19,7 +19,9 @@ export class UsersRoutes extends CommonRoutesConfig {
             .route(`/users`)
             .get(
                 jwtMiddleware.validJWTNeeded,
-                permissionMiddleware.onlyAdminCanDoThisAction,
+                permissionMiddleware.permissionFlagRequired(
+                    PermissionFlag.ADMIN_PERMISSION
+                ),
                 UsersController.listUsers
             )
             .post(
@@ -79,7 +81,7 @@ export class UsersRoutes extends CommonRoutesConfig {
 
         /**
          * This route does not currently require extra permissions.
-         * 
+         *
          * Please update it for admin usage in your own application!
          */
         this.app.put(`/users/:userId/permissionFlags/:permissionFlags`, [


### PR DESCRIPTION
Suite passes, and manual testing worked as well (401's without token, 403's with non-admin token, 200's with admin token)